### PR TITLE
chore(npm-script): simplified npm scripts commands

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,8 +27,8 @@
         "lab": "10.x.x"
     },
     "scripts": {
-        "test": "node node_modules/lab/bin/lab -a code -t 100 -L -m 10000",
-        "test-cov-html": "node node_modules/lab/bin/lab -a code -r html -o coverage.html -m 10000"
+        "test": "lab -a code -t 100 -L -m 10000",
+        "test-cov-html": "lab -a code -r html -o coverage.html -m 10000"
     },
     "license": "BSD-3-Clause"
 }


### PR DESCRIPTION
https://docs.npmjs.com/cli/run-script#description

>In addition to the shell's pre-existing PATH, npm run adds node_modules/.bin to the PATH provided to scripts. Any binaries provided by locally-installed dependencies can be used without the node_modules/.bin prefix. For example, if there is a devDependency on tap in your package, you should write:

> `"scripts": {"test": "tap test/\*.js"}` instead of `"scripts": {"test": "node_modules/.bin/tap test/\*.js"}` to run your tests.