### PR TITLE
Modify the default template for image embeds

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -279,10 +279,10 @@ internals.preview = function (description, options, callback) {
                 ${options.script ? '<script type="text/javascript" charset="utf-8" src="' + options.script + '"></script>' : ''}
             </head>
             <body>
-                <div class='metaphor-embed'>
+                <div class='metaphor-embed${description.site_name === 'Image' ? ' metaphor-embed-image-embed' : ''}'>
                     <div class='metaphor-embed-header'>
                         ${icon ? '<img class="metaphor-embed-header-icon" src="' + icon + '"/>' : '<div class="metaphor-embed-header-icon-missing"></div>'}
-                        <div class="metaphor-embed-header-site">${description.site_name}</div>
+                        ${description.site_name !== 'Image' ? '<div class="metaphor-embed-header-site">' + description.site_name + '</div>' : ''}
                         <a class="metaphor-embed-header-link" href="${url}" target="_blank">
                             <div class="metaphor-embed-header-title">${description.title || description.url}</div>
                         </a>

--- a/test/index.js
+++ b/test/index.js
@@ -323,7 +323,7 @@ describe('Metaphor', () => {
                             type: 'photo',
                             size: 17014
                         },
-                        preview: '<!DOCTYPE html><html><head></head><body><div class=\'metaphor-embed\'><div class=\'metaphor-embed-header\'><div class="metaphor-embed-header-icon-missing"></div><div class="metaphor-embed-header-site">Image</div><a class="metaphor-embed-header-link" href="https://www.sideway.com/sideway.png" target="_blank"><div class="metaphor-embed-header-title">https://www.sideway.com/sideway.png</div></a></div><div class=\'metaphor-embed-body no-description has-image\'><div class="metaphor-embed-body-description"></div><div class="metaphor-embed-body-image-wrapper"><img class="metaphor-embed-body-image" src="https://www.sideway.com/sideway.png"/></div></div></div></body></html>',
+                        preview: '<!DOCTYPE html><html><head></head><body><div class=\'metaphor-embed metaphor-embed-image-embed\'><div class=\'metaphor-embed-header\'><div class="metaphor-embed-header-icon-missing"></div><a class="metaphor-embed-header-link" href="https://www.sideway.com/sideway.png" target="_blank"><div class="metaphor-embed-header-title">https://www.sideway.com/sideway.png</div></a></div><div class=\'metaphor-embed-body no-description has-image\'><div class="metaphor-embed-body-description"></div><div class="metaphor-embed-body-image-wrapper"><img class="metaphor-embed-body-image" src="https://www.sideway.com/sideway.png"/></div></div></div></body></html>',
                         sources: ['resource']
                     });
 
@@ -345,7 +345,7 @@ describe('Metaphor', () => {
                             type: 'photo',
                             size: 17014
                         },
-                        preview: '<!DOCTYPE html><html><head></head><body><div class=\'metaphor-embed\'><div class=\'metaphor-embed-header\'><div class="metaphor-embed-header-icon-missing"></div><div class="metaphor-embed-header-site">Image</div><a class="metaphor-embed-header-link" href="https://www.sideway.com/sideway.png" target="_blank"><div class="metaphor-embed-header-title">https://www.sideway.com/sideway.png</div></a></div><div class=\'metaphor-embed-body no-description no-image\'><div class="metaphor-embed-body-description"></div><div class="metaphor-embed-body-image-missing"></div></div></div></body></html>',
+                        preview: '<!DOCTYPE html><html><head></head><body><div class=\'metaphor-embed metaphor-embed-image-embed\'><div class=\'metaphor-embed-header\'><div class="metaphor-embed-header-icon-missing"></div><a class="metaphor-embed-header-link" href="https://www.sideway.com/sideway.png" target="_blank"><div class="metaphor-embed-header-title">https://www.sideway.com/sideway.png</div></a></div><div class=\'metaphor-embed-body no-description no-image\'><div class="metaphor-embed-body-description"></div><div class="metaphor-embed-body-image-missing"></div></div></div></body></html>',
                         sources: ['resource']
                     });
 
@@ -367,7 +367,7 @@ describe('Metaphor', () => {
                             type: 'photo',
                             size: 17014
                         },
-                        preview: '<!DOCTYPE html><html><head></head><body><div class=\'metaphor-embed\'><div class=\'metaphor-embed-header\'><div class="metaphor-embed-header-icon-missing"></div><div class="metaphor-embed-header-site">Image</div><a class="metaphor-embed-header-link" href="https://www.sideway.com/sideway.png" target="_blank"><div class="metaphor-embed-header-title">https://www.sideway.com/sideway.png</div></a></div><div class=\'metaphor-embed-body no-description has-image\'><div class="metaphor-embed-body-description"></div><div class="metaphor-embed-body-image-wrapper"><img class="metaphor-embed-body-image" src="https://www.sideway.com/sideway.png"/></div></div></div></body></html>',
+                        preview: '<!DOCTYPE html><html><head></head><body><div class=\'metaphor-embed metaphor-embed-image-embed\'><div class=\'metaphor-embed-header\'><div class="metaphor-embed-header-icon-missing"></div><a class="metaphor-embed-header-link" href="https://www.sideway.com/sideway.png" target="_blank"><div class="metaphor-embed-header-title">https://www.sideway.com/sideway.png</div></a></div><div class=\'metaphor-embed-body no-description has-image\'><div class="metaphor-embed-body-description"></div><div class="metaphor-embed-body-image-wrapper"><img class="metaphor-embed-body-image" src="https://www.sideway.com/sideway.png"/></div></div></div></body></html>',
                         sources: ['resource']
                     });
 


### PR DESCRIPTION
- Do not show the `site_name` if it is 'Image'

- Add a class onto the embed if the embed is an image